### PR TITLE
chore: rebuild against PySide BaseApp 6.10.3

### DIFF
--- a/eu.codepoems.xl-converter.yaml
+++ b/eu.codepoems.xl-converter.yaml
@@ -4,7 +4,7 @@ runtime-version: '6.10'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
-base: io.qt.PySide.BaseApp
+base: io.qt.PySide.BaseApp  # Rebuild against 6.10.3
 base-version: '6.10'
 command: run.sh
 build-options:


### PR DESCRIPTION
This PR rebuilds XL Converter against a newer PySide BaseApp that matches the Qt in the updated KDE Runtime.

It stopped launching due to an ABI mismatch between Qt versions from the KDE Runtime and PySide BaseApp. PySide.BaseApp had a PR merged fix this, but a BaseApp update does not trigger a rebuild on applications depending it.